### PR TITLE
Sync falco-exporter chart with SCC support

### DIFF
--- a/helm-charts/falco-exporter/CHANGELOG.md
+++ b/helm-charts/falco-exporter/CHANGELOG.md
@@ -3,6 +3,18 @@
 This file documents all notable changes to `falco-exporter` Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.3.5
+
+### Minor Changes
+
+* Add SecurityContextConstraint to allow deploying in Openshift
+
+## v0.3.4
+
+### Minor Changes
+
+* Add priorityClassName to values
+
 ## v0.3.3
 
 ### Minor Changes

--- a/helm-charts/falco-exporter/Chart.yaml
+++ b/helm-charts/falco-exporter/Chart.yaml
@@ -15,4 +15,4 @@ name: falco-exporter
 sources:
 - https://github.com/falcosecurity/falco-exporter
 type: application
-version: 0.3.3
+version: 0.3.5

--- a/helm-charts/falco-exporter/README.md
+++ b/helm-charts/falco-exporter/README.md
@@ -51,13 +51,15 @@ The following table lists the main configurable parameters of the chart and thei
 | `image.tag`                       | The image tag to pull                                                                            | `0.3.0`                            |
 | `image.pullPolicy`                | The image pull policy                                                                            | `IfNotPresent`                     |
 | `falco.grpcUnixSocketPath`        | Unix socket path for connecting to a Falco gRPC server                                           | `unix:///var/run/falco/falco.sock` |
-| `falco.grpcTimeout`               | The image tag to pull                                                                            | `2m`                               |
+| `falco.grpcTimeout`               | gRPC connection timeout                                                                          | `2m`                               |
 | `serviceMonitor.enabled`          | Enabled deployment of a Prometheus operator Service Monitor                                      | `false`                            |
 | `serviceMonitor.additionalLabels` | Add additional Labels to the Service Monitor                                                     | `{}`                               |
 | `serviceMonitor.interval`         | Specify a user defined interval for the Service Monitor                                          | `""`                               |
-| `serviceMonitor.scrapeTimeout`    | Specify a user defined scrape timeout for the Service Monitor                                    | `""`                               |  |
+| `serviceMonitor.scrapeTimeout`    | Specify a user defined scrape timeout for the Service Monitor                                    | `""`                               |
 | `grafanaDashboard.enabled`        | Enable the falco security dashboard, see https://github.com/falcosecurity/falco-exporter#grafana | `false`                            |
 | `grafanaDashboard.namespace`      | The namespace to deploy the dashboard configmap in                                               | `default`                          |
+| `scc.create`                      | Create OpenShift's Security Context Constraint                                                   | `true`                             |
+
 
 Please, refer to [values.yaml](./values.yaml) for the full list of configurable parameters.
 

--- a/helm-charts/falco-exporter/templates/daemonset.yaml
+++ b/helm-charts/falco-exporter/templates/daemonset.yaml
@@ -17,6 +17,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
       serviceAccountName: {{ include "falco-exporter.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -63,7 +66,7 @@ spec:
       volumes:
       {{- if .Values.falco.grpcUnixSocketPath }}
         - name: falco-socket-dir
-          hostPath: 
+          hostPath:
             path: {{ include "falco-exporter.unixSocketDir" . }}
       {{- else }}
         - name: certs-volume

--- a/helm-charts/falco-exporter/templates/securitycontextconstraints.yaml
+++ b/helm-charts/falco-exporter/templates/securitycontextconstraints.yaml
@@ -1,0 +1,40 @@
+{{- if and .Values.scc.create (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: |
+      This provides the minimum requirements Falco-exporter to run in Openshift.
+  name: {{ template "falco-exporter.fullname" . }}
+  labels:
+    {{- include "falco-exporter.labels" . | nindent 4 }}
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: []
+allowedUnsafeSysctls: []
+defaultAddCapabilities: []
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: 0
+readOnlyRootFilesystem: false
+requiredDropCapabilities: []
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+- '*'
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{ .Release.Namespace }}:{{ include "falco-exporter.serviceAccountName" . }}
+volumes:
+- hostPath
+- secret
+{{- end }}

--- a/helm-charts/falco-exporter/values.yaml
+++ b/helm-charts/falco-exporter/values.yaml
@@ -22,6 +22,8 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+priorityClassName:
+
 falco:
   grpcUnixSocketPath: "unix:///var/run/falco/falco.sock"
   grpcTimeout: 2m
@@ -80,3 +82,7 @@ serviceMonitor:
 grafanaDashboard:
   enabled: false
   namespace: default
+
+scc:
+  # true here enabled creation of Security Context Constraints in Openshift
+  create: true


### PR DESCRIPTION
Sync with latest version of the falco-exporter chart, and include changes from unmerged PR https://github.com/falcosecurity/charts/pull/51 to include support for SCC in Openshift.

Signed-off-by: Alvaro Iradier <airadier@gmail.com>